### PR TITLE
Removed some `/*` comment chars that were causing build warnings

### DIFF
--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -70,18 +70,19 @@ void AMS_5600::setOutPut(uint8_t mode)
     }
     writeOneByte(_conf_lo, lowByte(config_status));
   }
-  /****************************************************
+}
+/****************************************************
   Method: AMS_5600
   In: none
   Out: i2c address of AMS 5600
   Description: returns i2c address of AMS 5600
 /***************************************************/
-  int AMS_5600::getAddress()
-  {
-    return _ams5600_Address;
-  }
+int AMS_5600::getAddress()
+{
+  return _ams5600_Address;
+}
 
-  /*******************************************************
+/*******************************************************
   Method: setMaxAngle
   In: new maximum angle to set OR none
   Out: value of max angle register
@@ -90,37 +91,37 @@ void AMS_5600::setOutPut(uint8_t mode)
   magnet.  Setting this register zeros out max position
   register.
 *******************************************************/
-  word AMS_5600::setMaxAngle(word newMaxAngle)
+word AMS_5600::setMaxAngle(word newMaxAngle)
+{
+  word retVal;
+  if (newMaxAngle == -1)
   {
-    word retVal;
-    if (newMaxAngle == -1)
-    {
-      _maxAngle = getRawAngle();
-    }
-    else
-      _maxAngle = newMaxAngle;
-
-    writeOneByte(_mang_hi, highByte(_maxAngle));
-    delay(2);
-    writeOneByte(_mang_lo, lowByte(_maxAngle));
-    delay(2);
-
-    retVal = readTwoBytes(_mang_hi, _mang_lo);
-    return retVal;
+    _maxAngle = getRawAngle();
   }
+  else
+    _maxAngle = newMaxAngle;
 
-  /*******************************************************
+  writeOneByte(_mang_hi, highByte(_maxAngle));
+  delay(2);
+  writeOneByte(_mang_lo, lowByte(_maxAngle));
+  delay(2);
+
+  retVal = readTwoBytes(_mang_hi, _mang_lo);
+  return retVal;
+}
+
+/*******************************************************
   Method: getMaxAngle
   In: none
   Out: value of max angle register
   Description: gets value of maximum angle register.
 *******************************************************/
-  word AMS_5600::getMaxAngle()
-  {
-    return readTwoBytes(_mang_hi, _mang_lo);
-  }
+word AMS_5600::getMaxAngle()
+{
+  return readTwoBytes(_mang_hi, _mang_lo);
+}
 
-  /*******************************************************
+/*******************************************************
   Method: setStartPosition
   In: new start angle position
   Out: value of start position register
@@ -128,36 +129,36 @@ void AMS_5600::setOutPut(uint8_t mode)
   If no value is provided, method will read position of
   magnet.  
 *******************************************************/
-  word AMS_5600::setStartPosition(word startAngle)
+word AMS_5600::setStartPosition(word startAngle)
+{
+  if (startAngle == -1)
   {
-    if (startAngle == -1)
-    {
-      _rawStartAngle = getRawAngle();
-    }
-    else
-      _rawStartAngle = startAngle;
-
-    writeOneByte(_zpos_hi, highByte(_rawStartAngle));
-    delay(2);
-    writeOneByte(_zpos_lo, lowByte(_rawStartAngle));
-    delay(2);
-    _zPosition = readTwoBytes(_zpos_hi, _zpos_lo);
-
-    return (_zPosition);
+    _rawStartAngle = getRawAngle();
   }
+  else
+    _rawStartAngle = startAngle;
 
-  /*******************************************************
+  writeOneByte(_zpos_hi, highByte(_rawStartAngle));
+  delay(2);
+  writeOneByte(_zpos_lo, lowByte(_rawStartAngle));
+  delay(2);
+  _zPosition = readTwoBytes(_zpos_hi, _zpos_lo);
+
+  return (_zPosition);
+}
+
+/*******************************************************
   Method: getStartPosition
   In: none
   Out: value of start position register
   Description: gets value of start position register.
 *******************************************************/
-  word AMS_5600::getStartPosition()
-  {
-    return readTwoBytes(_zpos_hi, _zpos_lo);
-  }
+word AMS_5600::getStartPosition()
+{
+  return readTwoBytes(_zpos_hi, _zpos_lo);
+}
 
-  /*******************************************************
+/*******************************************************
   Method: setEndtPosition
   In: new end angle position
   Out: value of end position register
@@ -165,47 +166,47 @@ void AMS_5600::setOutPut(uint8_t mode)
   If no value is provided, method will read position of
   magnet.  
 *******************************************************/
-  word AMS_5600::setEndPosition(word endAngle)
-  {
-    if (endAngle == -1)
-      _rawEndAngle = getRawAngle();
-    else
-      _rawEndAngle = endAngle;
+word AMS_5600::setEndPosition(word endAngle)
+{
+  if (endAngle == -1)
+    _rawEndAngle = getRawAngle();
+  else
+    _rawEndAngle = endAngle;
 
-    writeOneByte(_mpos_hi, highByte(_rawEndAngle));
-    delay(2);
-    writeOneByte(_mpos_lo, lowByte(_rawEndAngle));
-    delay(2);
-    _mPosition = readTwoBytes(_mpos_hi, _mpos_lo);
+  writeOneByte(_mpos_hi, highByte(_rawEndAngle));
+  delay(2);
+  writeOneByte(_mpos_lo, lowByte(_rawEndAngle));
+  delay(2);
+  _mPosition = readTwoBytes(_mpos_hi, _mpos_lo);
 
-    return (_mPosition);
-  }
+  return (_mPosition);
+}
 
-  /*******************************************************
+/*******************************************************
   Method: getEndPosition
   In: none
   Out: value of end position register
   Description: gets value of end position register.
 *******************************************************/
-  word AMS_5600::getEndPosition()
-  {
-    word retVal = readTwoBytes(_mpos_hi, _mpos_lo);
-    return retVal;
-  }
+word AMS_5600::getEndPosition()
+{
+  word retVal = readTwoBytes(_mpos_hi, _mpos_lo);
+  return retVal;
+}
 
-  /*******************************************************
+/*******************************************************
   Method: getRawAngle
   In: none
   Out: value of raw angle register
   Description: gets raw value of magnet position.
   start, end, and max angle settings do not apply
 *******************************************************/
-  word AMS_5600::getRawAngle()
-  {
-    return readTwoBytes(_raw_ang_hi, _raw_ang_lo);
-  }
+word AMS_5600::getRawAngle()
+{
+  return readTwoBytes(_raw_ang_hi, _raw_ang_lo);
+}
 
-  /*******************************************************
+/*******************************************************
   Method: getScaledAngle
   In: none
   Out: value of scaled angle register
@@ -213,35 +214,35 @@ void AMS_5600::setOutPut(uint8_t mode)
   start, end, or max angle settings are used to 
   determine value
 *******************************************************/
-  word AMS_5600::getScaledAngle()
-  {
-    return readTwoBytes(_ang_hi, _ang_lo);
-  }
+word AMS_5600::getScaledAngle()
+{
+  return readTwoBytes(_ang_hi, _ang_lo);
+}
 
-  /*******************************************************
+/*******************************************************
   Method: detectMagnet
   In: none
   Out: 1 if magnet is detected, 0 if not
   Description: reads status register and examines the 
   MH bit
 *******************************************************/
-  int AMS_5600::detectMagnet()
-  {
-    int magStatus;
-    int retVal = 0;
-    /*0 0 MD ML MH 0 0 0*/
-    /* MD high = magnet detected*/
-    /* ML high = AGC Maximum overflow, magnet to weak*/
-    /* MH high = AGC minimum overflow, Magnet to strong*/
-    magStatus = readOneByte(_stat);
+int AMS_5600::detectMagnet()
+{
+  int magStatus;
+  int retVal = 0;
+  /*0 0 MD ML MH 0 0 0*/
+  /* MD high = magnet detected*/
+  /* ML high = AGC Maximum overflow, magnet to weak*/
+  /* MH high = AGC minimum overflow, Magnet to strong*/
+  magStatus = readOneByte(_stat);
 
-    if (magStatus & 0x20)
-      retVal = 1;
+  if (magStatus & 0x20)
+    retVal = 1;
 
-    return retVal;
-  }
+  return retVal;
+}
 
-  /*******************************************************
+/*******************************************************
   Method: getMagnetStrength
   In: none
   Out: 0 if no magnet is detected
@@ -250,62 +251,62 @@ void AMS_5600::setOutPut(uint8_t mode)
        3 if magnet is to strong
   Description: reads status register andexamins the MH,ML,MD bits
 *******************************************************/
-  int AMS_5600::getMagnetStrength()
+int AMS_5600::getMagnetStrength()
+{
+  int magStatus;
+  int retVal = 0;
+  /*0 0 MD ML MH 0 0 0*/
+  /* MD high = magnet detected */
+  /* ML high = AGC Maximum overflow, magnet to weak*/
+  /* MH high = AGC minimum overflow, Magnet to strong*/
+  magStatus = readOneByte(_stat);
+  if (detectMagnet() == 1)
   {
-    int magStatus;
-    int retVal = 0;
-    /*0 0 MD ML MH 0 0 0*/
-    /* MD high = magnet detected */
-    /* ML high = AGC Maximum overflow, magnet to weak*/
-    /* MH high = AGC minimum overflow, Magnet to strong*/
-    magStatus = readOneByte(_stat);
-    if (detectMagnet() == 1)
-    {
-      retVal = 2; /*just right */
-      if (magStatus & 0x10)
-        retVal = 1; /*to weak */
-      else if (magStatus & 0x08)
-        retVal = 3; /*to strong */
-    }
-
-    return retVal;
+    retVal = 2; /*just right */
+    if (magStatus & 0x10)
+      retVal = 1; /*to weak */
+    else if (magStatus & 0x08)
+      retVal = 3; /*to strong */
   }
 
-  /*******************************************************
+  return retVal;
+}
+
+/*******************************************************
   Method: get Agc
   In: none
   Out: value of AGC register
   Description: gets value of AGC register.
 *******************************************************/
-  int AMS_5600::getAgc()
-  {
-    return readOneByte(_agc);
-  }
+int AMS_5600::getAgc()
+{
+  return readOneByte(_agc);
+}
 
-  /*******************************************************
+/*******************************************************
   Method: getMagnitude
   In: none
   Out: value of magnitude register
   Description: gets value of magnitude register.
 *******************************************************/
-  word AMS_5600::getMagnitude()
-  {
-    return readTwoBytes(_mag_hi, _mag_lo);
-  }
+word AMS_5600::getMagnitude()
+{
+  return readTwoBytes(_mag_hi, _mag_lo);
+}
 
-  /*******************************************************
+/*******************************************************
   Method: getBurnCount
   In: none
   Out: value of zmco register
   Description: determines how many times chip has been
   permanently written to. 
 *******************************************************/
-  int AMS_5600::getBurnCount()
-  {
-    return readOneByte(_zmco);
-  }
+int AMS_5600::getBurnCount()
+{
+  return readOneByte(_zmco);
+}
 
-  /*******************************************************
+/*******************************************************
   Method: burnAngle
   In: none
   Out: 1 success
@@ -315,32 +316,32 @@ void AMS_5600::setOutPut(uint8_t mode)
   Description: burns start and end positions to chip.
   THIS CAN ONLY BE DONE 3 TIMES
 *******************************************************/
-  int AMS_5600::burnAngle()
-  {
-    int retVal = 1;
-    _zPosition = getStartPosition();
-    _mPosition = getEndPosition();
-    _maxAngle = getMaxAngle();
+int AMS_5600::burnAngle()
+{
+  int retVal = 1;
+  _zPosition = getStartPosition();
+  _mPosition = getEndPosition();
+  _maxAngle = getMaxAngle();
 
-    if (detectMagnet() == 1)
+  if (detectMagnet() == 1)
+  {
+    if (getBurnCount() < 3)
     {
-      if (getBurnCount() < 3)
-      {
-        if ((_zPosition == 0) && (_mPosition == 0))
-          retVal = -3;
-        else
-          writeOneByte(_burn, 0x80);
-      }
+      if ((_zPosition == 0) && (_mPosition == 0))
+        retVal = -3;
       else
-        retVal = -2;
+        writeOneByte(_burn, 0x80);
     }
     else
-      retVal = -1;
-
-    return retVal;
+      retVal = -2;
   }
+  else
+    retVal = -1;
 
-  /*******************************************************
+  return retVal;
+}
+
+/*******************************************************
   Method: burnMaxAngleAndConfig
   In: none
   Out: 1 success
@@ -349,92 +350,92 @@ void AMS_5600::setOutPut(uint8_t mode)
   Description: burns max angle and config data to chip.
   THIS CAN ONLY BE DONE 1 TIME
 *******************************************************/
-  int AMS_5600::burnMaxAngleAndConfig()
+int AMS_5600::burnMaxAngleAndConfig()
+{
+  int retVal = 1;
+  _maxAngle = getMaxAngle();
+
+  if (getBurnCount() == 0)
   {
-    int retVal = 1;
-    _maxAngle = getMaxAngle();
-
-    if (getBurnCount() == 0)
-    {
-      if (_maxAngle * 0.087 < 18)
-        retVal = -2;
-      else
-        writeOneByte(_burn, 0x40);
-    }
+    if (_maxAngle * 0.087 < 18)
+      retVal = -2;
     else
-      retVal = -1;
-
-    return retVal;
+      writeOneByte(_burn, 0x40);
   }
+  else
+    retVal = -1;
 
-  /*******************************************************
+  return retVal;
+}
+
+/*******************************************************
   Method: readOneByte
   In: register to read
   Out: data read from i2c
   Description: reads one byte register from i2c
 *******************************************************/
-  int AMS_5600::readOneByte(int in_adr)
-  {
-    int retVal = -1;
-    Wire.beginTransmission(_ams5600_Address);
-    Wire.write(in_adr);
-    Wire.endTransmission();
-    Wire.requestFrom(_ams5600_Address, 1);
-    while (Wire.available() == 0)
-      ;
-    retVal = Wire.read();
+int AMS_5600::readOneByte(int in_adr)
+{
+  int retVal = -1;
+  Wire.beginTransmission(_ams5600_Address);
+  Wire.write(in_adr);
+  Wire.endTransmission();
+  Wire.requestFrom(_ams5600_Address, 1);
+  while (Wire.available() == 0)
+    ;
+  retVal = Wire.read();
 
-    return retVal;
-  }
+  return retVal;
+}
 
-  /*******************************************************
+/*******************************************************
   Method: readTwoBytes
   In: two registers to read
   Out: data read from i2c as a word
   Description: reads two bytes register from i2c
 *******************************************************/
-  word AMS_5600::readTwoBytes(int in_adr_hi, int in_adr_lo)
-  {
-    word retVal = -1;
+word AMS_5600::readTwoBytes(int in_adr_hi, int in_adr_lo)
+{
+  word retVal = -1;
 
-    /* Read Low Byte */
-    Wire.beginTransmission(_ams5600_Address);
-    Wire.write(in_adr_lo);
-    Wire.endTransmission();
-    Wire.requestFrom(_ams5600_Address, 1);
-    while (Wire.available() == 0)
-      ;
-    int low = Wire.read();
+  /* Read Low Byte */
+  Wire.beginTransmission(_ams5600_Address);
+  Wire.write(in_adr_lo);
+  Wire.endTransmission();
+  Wire.requestFrom(_ams5600_Address, 1);
+  while (Wire.available() == 0)
+    ;
+  int low = Wire.read();
 
-    /* Read High Byte */
-    Wire.beginTransmission(_ams5600_Address);
-    Wire.write(in_adr_hi);
-    Wire.endTransmission();
-    Wire.requestFrom(_ams5600_Address, 1);
+  /* Read High Byte */
+  Wire.beginTransmission(_ams5600_Address);
+  Wire.write(in_adr_hi);
+  Wire.endTransmission();
+  Wire.requestFrom(_ams5600_Address, 1);
 
-    while (Wire.available() == 0)
-      ;
+  while (Wire.available() == 0)
+    ;
 
-    word high = Wire.read();
+  word high = Wire.read();
 
-    high = high << 8;
-    retVal = high | low;
+  high = high << 8;
+  retVal = high | low;
 
-    return retVal;
-  }
+  return retVal;
+}
 
-  /*******************************************************
+/*******************************************************
   Method: writeOneByte
   In: address and data to write
   Out: none
   Description: writes one byte to a i2c register
 *******************************************************/
-  void AMS_5600::writeOneByte(int adr_in, int dat_in)
-  {
-    Wire.beginTransmission(_ams5600_Address);
-    Wire.write(adr_in);
-    Wire.write(dat_in);
-    Wire.endTransmission();
-  }
+void AMS_5600::writeOneByte(int adr_in, int dat_in)
+{
+  Wire.beginTransmission(_ams5600_Address);
+  Wire.write(adr_in);
+  Wire.write(dat_in);
+  Wire.endTransmission();
+}
 
-  /**********  END OF AMS 5600 CALSS *****************/
+/**********  END OF AMS 5600 CALSS *****************/

--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -47,7 +47,7 @@ AMS_5600::AMS_5600()
   _mag_lo = 0x1c;
   _burn = 0xff;
 }
-/* mode = 0, output PWM, mode = 1 output analog (full range from 0% to 100% between GND and VDD*/
+/* mode = 0, output PWM, mode = 1 output analog (full range from 0% to 100% between GND and VDD */
 void AMS_5600::setOutPut(uint8_t mode)
 {
   uint8_t config_status;

--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -9,7 +9,7 @@
    
   Description:  This class has been designed to
   access the AMS 5600 “potuino” shield.
-/***************************************************/
+*****************************************************/
 
 #include "Arduino.h"
 #include "AS5600.h"
@@ -20,7 +20,7 @@
   In: none
   Out: none
   Description: constructor class for AMS 5600
-/***************************************************/
+*****************************************************/
 AMS_5600::AMS_5600()
 {
   /* set i2c address */
@@ -76,7 +76,7 @@ void AMS_5600::setOutPut(uint8_t mode)
   In: none
   Out: i2c address of AMS 5600
   Description: returns i2c address of AMS 5600
-/***************************************************/
+****************************************************/
 int AMS_5600::getAddress()
 {
   return _ams5600_Address;

--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -23,8 +23,8 @@
 /***************************************************/
 AMS_5600::AMS_5600()
 {
-  set i2c address * /
-      _ams5600_Address = 0x36;
+  /* set i2c address * /
+  /* _ams5600_Address = 0x36;
 
   load register values * /
       c++ class forbids pre loading of variables * /
@@ -48,32 +48,32 @@ AMS_5600::AMS_5600()
   _burn = 0xff;
 }
 /* mode = 0, output PWM, mode = 1 output analog (full range from 0% to 100% between GND and VDD*/
-void AMS_5600::setOutPut(uint8_t mode)
-{
-  uint8_t config_status;
-  config_status = readOneByte(_conf_lo);
-  if (mode == 1)
+  void AMS_5600::setOutPut(uint8_t mode)
   {
-    config_status = config_status & 0xcf;
+    uint8_t config_status;
+    config_status = readOneByte(_conf_lo);
+    if (mode == 1)
+    {
+      config_status = config_status & 0xcf;
+    }
+    else
+    {
+      config_status = config_status & 0xef;
+    }
+    writeOneByte(_conf_lo, lowByte(config_status));
   }
-  else
-  {
-    config_status = config_status & 0xef;
-  }
-  writeOneByte(_conf_lo, lowByte(config_status));
-}
-/****************************************************
+  /****************************************************
   Method: AMS_5600
   In: none
   Out: i2c address of AMS 5600
   Description: returns i2c address of AMS 5600
 /***************************************************/
-int AMS_5600::getAddress()
-{
-  return _ams5600_Address;
-}
+  int AMS_5600::getAddress()
+  {
+    return _ams5600_Address;
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: setMaxAngle
   In: new maximum angle to set OR none
   Out: value of max angle register
@@ -82,37 +82,37 @@ int AMS_5600::getAddress()
   magnet.  Setting this register zeros out max position
   register.
 *******************************************************/
-word AMS_5600::setMaxAngle(word newMaxAngle)
-{
-  word retVal;
-  if (newMaxAngle == -1)
+  word AMS_5600::setMaxAngle(word newMaxAngle)
   {
-    _maxAngle = getRawAngle();
+    word retVal;
+    if (newMaxAngle == -1)
+    {
+      _maxAngle = getRawAngle();
+    }
+    else
+      _maxAngle = newMaxAngle;
+
+    writeOneByte(_mang_hi, highByte(_maxAngle));
+    delay(2);
+    writeOneByte(_mang_lo, lowByte(_maxAngle));
+    delay(2);
+
+    retVal = readTwoBytes(_mang_hi, _mang_lo);
+    return retVal;
   }
-  else
-    _maxAngle = newMaxAngle;
 
-  writeOneByte(_mang_hi, highByte(_maxAngle));
-  delay(2);
-  writeOneByte(_mang_lo, lowByte(_maxAngle));
-  delay(2);
-
-  retVal = readTwoBytes(_mang_hi, _mang_lo);
-  return retVal;
-}
-
-/*******************************************************
+  /*******************************************************
   Method: getMaxAngle
   In: none
   Out: value of max angle register
   Description: gets value of maximum angle register.
 *******************************************************/
-word AMS_5600::getMaxAngle()
-{
-  return readTwoBytes(_mang_hi, _mang_lo);
-}
+  word AMS_5600::getMaxAngle()
+  {
+    return readTwoBytes(_mang_hi, _mang_lo);
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: setStartPosition
   In: new start angle position
   Out: value of start position register
@@ -120,36 +120,36 @@ word AMS_5600::getMaxAngle()
   If no value is provided, method will read position of
   magnet.  
 *******************************************************/
-word AMS_5600::setStartPosition(word startAngle)
-{
-  if (startAngle == -1)
+  word AMS_5600::setStartPosition(word startAngle)
   {
-    _rawStartAngle = getRawAngle();
+    if (startAngle == -1)
+    {
+      _rawStartAngle = getRawAngle();
+    }
+    else
+      _rawStartAngle = startAngle;
+
+    writeOneByte(_zpos_hi, highByte(_rawStartAngle));
+    delay(2);
+    writeOneByte(_zpos_lo, lowByte(_rawStartAngle));
+    delay(2);
+    _zPosition = readTwoBytes(_zpos_hi, _zpos_lo);
+
+    return (_zPosition);
   }
-  else
-    _rawStartAngle = startAngle;
 
-  writeOneByte(_zpos_hi, highByte(_rawStartAngle));
-  delay(2);
-  writeOneByte(_zpos_lo, lowByte(_rawStartAngle));
-  delay(2);
-  _zPosition = readTwoBytes(_zpos_hi, _zpos_lo);
-
-  return (_zPosition);
-}
-
-/*******************************************************
+  /*******************************************************
   Method: getStartPosition
   In: none
   Out: value of start position register
   Description: gets value of start position register.
 *******************************************************/
-word AMS_5600::getStartPosition()
-{
-  return readTwoBytes(_zpos_hi, _zpos_lo);
-}
+  word AMS_5600::getStartPosition()
+  {
+    return readTwoBytes(_zpos_hi, _zpos_lo);
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: setEndtPosition
   In: new end angle position
   Out: value of end position register
@@ -157,47 +157,47 @@ word AMS_5600::getStartPosition()
   If no value is provided, method will read position of
   magnet.  
 *******************************************************/
-word AMS_5600::setEndPosition(word endAngle)
-{
-  if (endAngle == -1)
-    _rawEndAngle = getRawAngle();
-  else
-    _rawEndAngle = endAngle;
+  word AMS_5600::setEndPosition(word endAngle)
+  {
+    if (endAngle == -1)
+      _rawEndAngle = getRawAngle();
+    else
+      _rawEndAngle = endAngle;
 
-  writeOneByte(_mpos_hi, highByte(_rawEndAngle));
-  delay(2);
-  writeOneByte(_mpos_lo, lowByte(_rawEndAngle));
-  delay(2);
-  _mPosition = readTwoBytes(_mpos_hi, _mpos_lo);
+    writeOneByte(_mpos_hi, highByte(_rawEndAngle));
+    delay(2);
+    writeOneByte(_mpos_lo, lowByte(_rawEndAngle));
+    delay(2);
+    _mPosition = readTwoBytes(_mpos_hi, _mpos_lo);
 
-  return (_mPosition);
-}
+    return (_mPosition);
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: getEndPosition
   In: none
   Out: value of end position register
   Description: gets value of end position register.
 *******************************************************/
-word AMS_5600::getEndPosition()
-{
-  word retVal = readTwoBytes(_mpos_hi, _mpos_lo);
-  return retVal;
-}
+  word AMS_5600::getEndPosition()
+  {
+    word retVal = readTwoBytes(_mpos_hi, _mpos_lo);
+    return retVal;
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: getRawAngle
   In: none
   Out: value of raw angle register
   Description: gets raw value of magnet position.
   start, end, and max angle settings do not apply
 *******************************************************/
-word AMS_5600::getRawAngle()
-{
-  return readTwoBytes(_raw_ang_hi, _raw_ang_lo);
-}
+  word AMS_5600::getRawAngle()
+  {
+    return readTwoBytes(_raw_ang_hi, _raw_ang_lo);
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: getScaledAngle
   In: none
   Out: value of scaled angle register
@@ -205,35 +205,35 @@ word AMS_5600::getRawAngle()
   start, end, or max angle settings are used to 
   determine value
 *******************************************************/
-word AMS_5600::getScaledAngle()
-{
-  return readTwoBytes(_ang_hi, _ang_lo);
-}
+  word AMS_5600::getScaledAngle()
+  {
+    return readTwoBytes(_ang_hi, _ang_lo);
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: detectMagnet
   In: none
   Out: 1 if magnet is detected, 0 if not
   Description: reads status register and examines the 
   MH bit
 *******************************************************/
-int AMS_5600::detectMagnet()
-{
-  int magStatus;
-  int retVal = 0;
-  /*0 0 MD ML MH 0 0 0*/
-  /* MD high = magnet detected*/
-  /* ML high = AGC Maximum overflow, magnet to weak*/
-  /* MH high = AGC minimum overflow, Magnet to strong*/
-  magStatus = readOneByte(_stat);
+  int AMS_5600::detectMagnet()
+  {
+    int magStatus;
+    int retVal = 0;
+    /*0 0 MD ML MH 0 0 0*/
+    /* MD high = magnet detected*/
+    /* ML high = AGC Maximum overflow, magnet to weak*/
+    /* MH high = AGC minimum overflow, Magnet to strong*/
+    magStatus = readOneByte(_stat);
 
-  if (magStatus & 0x20)
-    retVal = 1;
+    if (magStatus & 0x20)
+      retVal = 1;
 
-  return retVal;
-}
+    return retVal;
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: getMagnetStrength
   In: none
   Out: 0 if no magnet is detected
@@ -242,62 +242,62 @@ int AMS_5600::detectMagnet()
        3 if magnet is to strong
   Description: reads status register andexamins the MH,ML,MD bits
 *******************************************************/
-int AMS_5600::getMagnetStrength()
-{
-  int magStatus;
-  int retVal = 0;
-  /*0 0 MD ML MH 0 0 0*/
-  /* MD high = magnet detected */
-  /* ML high = AGC Maximum overflow, magnet to weak*/
-  /* MH high = AGC minimum overflow, Magnet to strong*/
-  magStatus = readOneByte(_stat);
-  if (detectMagnet() == 1)
+  int AMS_5600::getMagnetStrength()
   {
-    retVal = 2; /*just right */
-    if (magStatus & 0x10)
-      retVal = 1; /*to weak */
-    else if (magStatus & 0x08)
-      retVal = 3; /*to strong */
+    int magStatus;
+    int retVal = 0;
+    /*0 0 MD ML MH 0 0 0*/
+    /* MD high = magnet detected */
+    /* ML high = AGC Maximum overflow, magnet to weak*/
+    /* MH high = AGC minimum overflow, Magnet to strong*/
+    magStatus = readOneByte(_stat);
+    if (detectMagnet() == 1)
+    {
+      retVal = 2; /*just right */
+      if (magStatus & 0x10)
+        retVal = 1; /*to weak */
+      else if (magStatus & 0x08)
+        retVal = 3; /*to strong */
+    }
+
+    return retVal;
   }
 
-  return retVal;
-}
-
-/*******************************************************
+  /*******************************************************
   Method: get Agc
   In: none
   Out: value of AGC register
   Description: gets value of AGC register.
 *******************************************************/
-int AMS_5600::getAgc()
-{
-  return readOneByte(_agc);
-}
+  int AMS_5600::getAgc()
+  {
+    return readOneByte(_agc);
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: getMagnitude
   In: none
   Out: value of magnitude register
   Description: gets value of magnitude register.
 *******************************************************/
-word AMS_5600::getMagnitude()
-{
-  return readTwoBytes(_mag_hi, _mag_lo);
-}
+  word AMS_5600::getMagnitude()
+  {
+    return readTwoBytes(_mag_hi, _mag_lo);
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: getBurnCount
   In: none
   Out: value of zmco register
   Description: determines how many times chip has been
   permanently written to. 
 *******************************************************/
-int AMS_5600::getBurnCount()
-{
-  return readOneByte(_zmco);
-}
+  int AMS_5600::getBurnCount()
+  {
+    return readOneByte(_zmco);
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: burnAngle
   In: none
   Out: 1 success
@@ -307,32 +307,32 @@ int AMS_5600::getBurnCount()
   Description: burns start and end positions to chip.
   THIS CAN ONLY BE DONE 3 TIMES
 *******************************************************/
-int AMS_5600::burnAngle()
-{
-  int retVal = 1;
-  _zPosition = getStartPosition();
-  _mPosition = getEndPosition();
-  _maxAngle = getMaxAngle();
-
-  if (detectMagnet() == 1)
+  int AMS_5600::burnAngle()
   {
-    if (getBurnCount() < 3)
+    int retVal = 1;
+    _zPosition = getStartPosition();
+    _mPosition = getEndPosition();
+    _maxAngle = getMaxAngle();
+
+    if (detectMagnet() == 1)
     {
-      if ((_zPosition == 0) && (_mPosition == 0))
-        retVal = -3;
+      if (getBurnCount() < 3)
+      {
+        if ((_zPosition == 0) && (_mPosition == 0))
+          retVal = -3;
+        else
+          writeOneByte(_burn, 0x80);
+      }
       else
-        writeOneByte(_burn, 0x80);
+        retVal = -2;
     }
     else
-      retVal = -2;
+      retVal = -1;
+
+    return retVal;
   }
-  else
-    retVal = -1;
 
-  return retVal;
-}
-
-/*******************************************************
+  /*******************************************************
   Method: burnMaxAngleAndConfig
   In: none
   Out: 1 success
@@ -341,92 +341,92 @@ int AMS_5600::burnAngle()
   Description: burns max angle and config data to chip.
   THIS CAN ONLY BE DONE 1 TIME
 *******************************************************/
-int AMS_5600::burnMaxAngleAndConfig()
-{
-  int retVal = 1;
-  _maxAngle = getMaxAngle();
-
-  if (getBurnCount() == 0)
+  int AMS_5600::burnMaxAngleAndConfig()
   {
-    if (_maxAngle * 0.087 < 18)
-      retVal = -2;
+    int retVal = 1;
+    _maxAngle = getMaxAngle();
+
+    if (getBurnCount() == 0)
+    {
+      if (_maxAngle * 0.087 < 18)
+        retVal = -2;
+      else
+        writeOneByte(_burn, 0x40);
+    }
     else
-      writeOneByte(_burn, 0x40);
+      retVal = -1;
+
+    return retVal;
   }
-  else
-    retVal = -1;
 
-  return retVal;
-}
-
-/*******************************************************
+  /*******************************************************
   Method: readOneByte
   In: register to read
   Out: data read from i2c
   Description: reads one byte register from i2c
 *******************************************************/
-int AMS_5600::readOneByte(int in_adr)
-{
-  int retVal = -1;
-  Wire.beginTransmission(_ams5600_Address);
-  Wire.write(in_adr);
-  Wire.endTransmission();
-  Wire.requestFrom(_ams5600_Address, 1);
-  while (Wire.available() == 0)
-    ;
-  retVal = Wire.read();
+  int AMS_5600::readOneByte(int in_adr)
+  {
+    int retVal = -1;
+    Wire.beginTransmission(_ams5600_Address);
+    Wire.write(in_adr);
+    Wire.endTransmission();
+    Wire.requestFrom(_ams5600_Address, 1);
+    while (Wire.available() == 0)
+      ;
+    retVal = Wire.read();
 
-  return retVal;
-}
+    return retVal;
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: readTwoBytes
   In: two registers to read
   Out: data read from i2c as a word
   Description: reads two bytes register from i2c
 *******************************************************/
-word AMS_5600::readTwoBytes(int in_adr_hi, int in_adr_lo)
-{
-  word retVal = -1;
+  word AMS_5600::readTwoBytes(int in_adr_hi, int in_adr_lo)
+  {
+    word retVal = -1;
 
-  /* Read Low Byte */
-  Wire.beginTransmission(_ams5600_Address);
-  Wire.write(in_adr_lo);
-  Wire.endTransmission();
-  Wire.requestFrom(_ams5600_Address, 1);
-  while (Wire.available() == 0)
-    ;
-  int low = Wire.read();
+    /* Read Low Byte */
+    Wire.beginTransmission(_ams5600_Address);
+    Wire.write(in_adr_lo);
+    Wire.endTransmission();
+    Wire.requestFrom(_ams5600_Address, 1);
+    while (Wire.available() == 0)
+      ;
+    int low = Wire.read();
 
-  /* Read High Byte */
-  Wire.beginTransmission(_ams5600_Address);
-  Wire.write(in_adr_hi);
-  Wire.endTransmission();
-  Wire.requestFrom(_ams5600_Address, 1);
+    /* Read High Byte */
+    Wire.beginTransmission(_ams5600_Address);
+    Wire.write(in_adr_hi);
+    Wire.endTransmission();
+    Wire.requestFrom(_ams5600_Address, 1);
 
-  while (Wire.available() == 0)
-    ;
+    while (Wire.available() == 0)
+      ;
 
-  word high = Wire.read();
+    word high = Wire.read();
 
-  high = high << 8;
-  retVal = high | low;
+    high = high << 8;
+    retVal = high | low;
 
-  return retVal;
-}
+    return retVal;
+  }
 
-/*******************************************************
+  /*******************************************************
   Method: writeOneByte
   In: address and data to write
   Out: none
   Description: writes one byte to a i2c register
 *******************************************************/
-void AMS_5600::writeOneByte(int adr_in, int dat_in)
-{
-  Wire.beginTransmission(_ams5600_Address);
-  Wire.write(adr_in);
-  Wire.write(dat_in);
-  Wire.endTransmission();
-}
+  void AMS_5600::writeOneByte(int adr_in, int dat_in)
+  {
+    Wire.beginTransmission(_ams5600_Address);
+    Wire.write(adr_in);
+    Wire.write(dat_in);
+    Wire.endTransmission();
+  }
 
-/**********  END OF AMS 5600 CALSS *****************/
+  /**********  END OF AMS 5600 CALSS *****************/

--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -23,12 +23,12 @@
 /***************************************************/
 AMS_5600::AMS_5600()
 {
-  set i2c address * /
-      _ams5600_Address = 0x36;
+  /* set i2c address */
+  _ams5600_Address = 0x36;
 
-  load register values * /
-      c++ class forbids pre loading of variables * /
-      _zmco = 0x00;
+  /* load register values */
+  /* c++ class forbids pre loading of variables */
+  _zmco = 0x00;
   _zpos_hi = 0x01;
   _zpos_lo = 0x02;
   _mpos_hi = 0x03;

--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -1,15 +1,14 @@
 
 /****************************************************
-/* AMS 5600 class for Arduino platform
-/* Author: Tom Denton
-/* Date: 15 Dec 2014 
-/* File: AMS_5600.cpp
-/* Version 1.00
-/* www.ams.com
-/*  
-/* Description:  This class has been designed to
-/* access the AMS 5600 “potuino” shield.
-/*
+  AMS 5600 class for Arduino platform
+  Author: Tom Denton
+  Date: 15 Dec 2014 
+  File: AMS_5600.cpp
+  Version 1.00
+  www.ams.com
+   
+  Description:  This class has been designed to
+  access the AMS 5600 “potuino” shield.
 /***************************************************/
 
 #include "Arduino.h"
@@ -17,26 +16,26 @@
 #include "Wire.h"
 
 /****************************************************
-/* Method: AMS_5600
-/* In: none
-/* Out: none
-/* Description: constructor class for AMS 5600
+  Method: AMS_5600
+  In: none
+  Out: none
+  Description: constructor class for AMS 5600
 /***************************************************/
 AMS_5600::AMS_5600()
 {
-  /* set i2c address */ 
-  _ams5600_Address = 0x36;
- 
-  /* load register values*/
-  /* c++ class forbids pre loading of variables */
-  _zmco = 0x00;
+  set i2c address * /
+      _ams5600_Address = 0x36;
+
+  load register values * /
+      c++ class forbids pre loading of variables * /
+      _zmco = 0x00;
   _zpos_hi = 0x01;
   _zpos_lo = 0x02;
   _mpos_hi = 0x03;
   _mpos_lo = 0x04;
   _mang_hi = 0x05;
   _mang_lo = 0x06;
-  _conf_hi = 0x07;    
+  _conf_hi = 0x07;
   _conf_lo = 0x08;
   _raw_ang_hi = 0x0c;
   _raw_ang_lo = 0x0d;
@@ -49,40 +48,44 @@ AMS_5600::AMS_5600()
   _burn = 0xff;
 }
 /* mode = 0, output PWM, mode = 1 output analog (full range from 0% to 100% between GND and VDD*/
-void AMS_5600::setOutPut(uint8_t mode){
-    uint8_t config_status;
-    config_status = readOneByte(_conf_lo);
-    if(mode == 1){
-        config_status = config_status & 0xcf;
-    }else{
-        config_status = config_status & 0xef;
-    }
-    writeOneByte(_conf_lo, lowByte(config_status)); 
+void AMS_5600::setOutPut(uint8_t mode)
+{
+  uint8_t config_status;
+  config_status = readOneByte(_conf_lo);
+  if (mode == 1)
+  {
+    config_status = config_status & 0xcf;
+  }
+  else
+  {
+    config_status = config_status & 0xef;
+  }
+  writeOneByte(_conf_lo, lowByte(config_status));
 }
 /****************************************************
-/* Method: AMS_5600
-/* In: none
-/* Out: i2c address of AMS 5600
-/* Description: returns i2c address of AMS 5600
+  Method: AMS_5600
+  In: none
+  Out: i2c address of AMS 5600
+  Description: returns i2c address of AMS 5600
 /***************************************************/
 int AMS_5600::getAddress()
 {
-  return _ams5600_Address; 
+  return _ams5600_Address;
 }
 
 /*******************************************************
-/* Method: setMaxAngle
-/* In: new maximum angle to set OR none
-/* Out: value of max angle register
-/* Description: sets a value in maximum angle register.
-/* If no value is provided, method will read position of
-/* magnet.  Setting this register zeros out max position
-/* register.
-/*******************************************************/
+  Method: setMaxAngle
+  In: new maximum angle to set OR none
+  Out: value of max angle register
+  Description: sets a value in maximum angle register.
+  If no value is provided, method will read position of
+  magnet.  Setting this register zeros out max position
+  register.
+*******************************************************/
 word AMS_5600::setMaxAngle(word newMaxAngle)
 {
   word retVal;
-  if(newMaxAngle == -1)
+  if (newMaxAngle == -1)
   {
     _maxAngle = getRawAngle();
   }
@@ -90,36 +93,36 @@ word AMS_5600::setMaxAngle(word newMaxAngle)
     _maxAngle = newMaxAngle;
 
   writeOneByte(_mang_hi, highByte(_maxAngle));
-  delay(2); 
-  writeOneByte(_mang_lo, lowByte(_maxAngle)); 
-  delay(2);         
+  delay(2);
+  writeOneByte(_mang_lo, lowByte(_maxAngle));
+  delay(2);
 
   retVal = readTwoBytes(_mang_hi, _mang_lo);
   return retVal;
 }
 
 /*******************************************************
-/* Method: getMaxAngle
-/* In: none
-/* Out: value of max angle register
-/* Description: gets value of maximum angle register.
-/*******************************************************/
+  Method: getMaxAngle
+  In: none
+  Out: value of max angle register
+  Description: gets value of maximum angle register.
+*******************************************************/
 word AMS_5600::getMaxAngle()
 {
   return readTwoBytes(_mang_hi, _mang_lo);
 }
 
 /*******************************************************
-/* Method: setStartPosition
-/* In: new start angle position
-/* Out: value of start position register
-/* Description: sets a value in start position register.
-/* If no value is provided, method will read position of
-/* magnet.  
-/*******************************************************/
+  Method: setStartPosition
+  In: new start angle position
+  Out: value of start position register
+  Description: sets a value in start position register.
+  If no value is provided, method will read position of
+  magnet.  
+*******************************************************/
 word AMS_5600::setStartPosition(word startAngle)
 {
-  if(startAngle == -1)
+  if (startAngle == -1)
   {
     _rawStartAngle = getRawAngle();
   }
@@ -127,242 +130,241 @@ word AMS_5600::setStartPosition(word startAngle)
     _rawStartAngle = startAngle;
 
   writeOneByte(_zpos_hi, highByte(_rawStartAngle));
-  delay(2); 
-  writeOneByte(_zpos_lo, lowByte(_rawStartAngle)); 
-  delay(2);                
+  delay(2);
+  writeOneByte(_zpos_lo, lowByte(_rawStartAngle));
+  delay(2);
   _zPosition = readTwoBytes(_zpos_hi, _zpos_lo);
-  
-  return(_zPosition);
+
+  return (_zPosition);
 }
 
 /*******************************************************
-/* Method: getStartPosition
-/* In: none
-/* Out: value of start position register
-/* Description: gets value of start position register.
-/*******************************************************/
+  Method: getStartPosition
+  In: none
+  Out: value of start position register
+  Description: gets value of start position register.
+*******************************************************/
 word AMS_5600::getStartPosition()
 {
   return readTwoBytes(_zpos_hi, _zpos_lo);
-}  
-
-/*******************************************************
-/* Method: setEndtPosition
-/* In: new end angle position
-/* Out: value of end position register
-/* Description: sets a value in end position register.
-/* If no value is provided, method will read position of
-/* magnet.  
-/*******************************************************/
-word AMS_5600::setEndPosition(word endAngle)
-{
-  if(endAngle == -1)
-    _rawEndAngle = getRawAngle();
-  else
-    _rawEndAngle = endAngle;
- 
-  writeOneByte(_mpos_hi, highByte(_rawEndAngle));
-  delay(2); 
-  writeOneByte(_mpos_lo, lowByte(_rawEndAngle)); 
-  delay(2);                
-  _mPosition = readTwoBytes(_mpos_hi, _mpos_lo);
-  
-  return(_mPosition);
 }
 
 /*******************************************************
-/* Method: getEndPosition
-/* In: none
-/* Out: value of end position register
-/* Description: gets value of end position register.
-/*******************************************************/
+  Method: setEndtPosition
+  In: new end angle position
+  Out: value of end position register
+  Description: sets a value in end position register.
+  If no value is provided, method will read position of
+  magnet.  
+*******************************************************/
+word AMS_5600::setEndPosition(word endAngle)
+{
+  if (endAngle == -1)
+    _rawEndAngle = getRawAngle();
+  else
+    _rawEndAngle = endAngle;
+
+  writeOneByte(_mpos_hi, highByte(_rawEndAngle));
+  delay(2);
+  writeOneByte(_mpos_lo, lowByte(_rawEndAngle));
+  delay(2);
+  _mPosition = readTwoBytes(_mpos_hi, _mpos_lo);
+
+  return (_mPosition);
+}
+
+/*******************************************************
+  Method: getEndPosition
+  In: none
+  Out: value of end position register
+  Description: gets value of end position register.
+*******************************************************/
 word AMS_5600::getEndPosition()
 {
   word retVal = readTwoBytes(_mpos_hi, _mpos_lo);
   return retVal;
-}  
+}
 
 /*******************************************************
-/* Method: getRawAngle
-/* In: none
-/* Out: value of raw angle register
-/* Description: gets raw value of magnet position.
-/* start, end, and max angle settings do not apply
-/*******************************************************/
+  Method: getRawAngle
+  In: none
+  Out: value of raw angle register
+  Description: gets raw value of magnet position.
+  start, end, and max angle settings do not apply
+*******************************************************/
 word AMS_5600::getRawAngle()
 {
   return readTwoBytes(_raw_ang_hi, _raw_ang_lo);
 }
 
 /*******************************************************
-/* Method: getScaledAngle
-/* In: none
-/* Out: value of scaled angle register
-/* Description: gets scaled value of magnet position.
-/* start, end, or max angle settings are used to 
-/* determine value
-/*******************************************************/
+  Method: getScaledAngle
+  In: none
+  Out: value of scaled angle register
+  Description: gets scaled value of magnet position.
+  start, end, or max angle settings are used to 
+  determine value
+*******************************************************/
 word AMS_5600::getScaledAngle()
 {
   return readTwoBytes(_ang_hi, _ang_lo);
 }
 
 /*******************************************************
-/* Method: detectMagnet
-/* In: none
-/* Out: 1 if magnet is detected, 0 if not
-/* Description: reads status register and examines the 
-/* MH bit
-/*******************************************************/
+  Method: detectMagnet
+  In: none
+  Out: 1 if magnet is detected, 0 if not
+  Description: reads status register and examines the 
+  MH bit
+*******************************************************/
 int AMS_5600::detectMagnet()
 {
   int magStatus;
   int retVal = 0;
   /*0 0 MD ML MH 0 0 0*/
   /* MD high = magnet detected*/
-  /* ML high = AGC Maximum overflow, magnet to weak*/ 
+  /* ML high = AGC Maximum overflow, magnet to weak*/
   /* MH high = AGC minimum overflow, Magnet to strong*/
   magStatus = readOneByte(_stat);
-  
-  if(magStatus & 0x20)
-    retVal = 1; 
-  
+
+  if (magStatus & 0x20)
+    retVal = 1;
+
   return retVal;
 }
 
 /*******************************************************
-/* Method: getMagnetStrength
-/* In: none
-/* Out: 0 if no magnet is detected
-/*      1 if magnet is to weak
-/*      2 if magnet is just right
-/*      3 if magnet is to strong
-/* Description: reads status register andexamins the MH,ML,MD bits
-/*******************************************************/
+  Method: getMagnetStrength
+  In: none
+  Out: 0 if no magnet is detected
+       1 if magnet is to weak
+       2 if magnet is just right
+       3 if magnet is to strong
+  Description: reads status register andexamins the MH,ML,MD bits
+*******************************************************/
 int AMS_5600::getMagnetStrength()
 {
   int magStatus;
   int retVal = 0;
   /*0 0 MD ML MH 0 0 0*/
   /* MD high = magnet detected */
-  /* ML high = AGC Maximum overflow, magnet to weak*/ 
-  /* MH high = AGC minimum overflow, Magnet to strong*/ 
+  /* ML high = AGC Maximum overflow, magnet to weak*/
+  /* MH high = AGC minimum overflow, Magnet to strong*/
   magStatus = readOneByte(_stat);
-  if(detectMagnet() ==1)
+  if (detectMagnet() == 1)
   {
-      retVal = 2; /*just right */
-      if(magStatus & 0x10)
-        retVal = 1; /*to weak */
-      else if(magStatus & 0x08)
-        retVal = 3; /*to strong */
+    retVal = 2; /*just right */
+    if (magStatus & 0x10)
+      retVal = 1; /*to weak */
+    else if (magStatus & 0x08)
+      retVal = 3; /*to strong */
   }
-  
+
   return retVal;
 }
 
 /*******************************************************
-/* Method: get Agc
-/* In: none
-/* Out: value of AGC register
-/* Description: gets value of AGC register.
-/*******************************************************/
+  Method: get Agc
+  In: none
+  Out: value of AGC register
+  Description: gets value of AGC register.
+*******************************************************/
 int AMS_5600::getAgc()
 {
   return readOneByte(_agc);
 }
 
 /*******************************************************
-/* Method: getMagnitude
-/* In: none
-/* Out: value of magnitude register
-/* Description: gets value of magnitude register.
-/*******************************************************/
+  Method: getMagnitude
+  In: none
+  Out: value of magnitude register
+  Description: gets value of magnitude register.
+*******************************************************/
 word AMS_5600::getMagnitude()
 {
-  return readTwoBytes(_mag_hi, _mag_lo);  
+  return readTwoBytes(_mag_hi, _mag_lo);
 }
 
 /*******************************************************
-/* Method: getBurnCount
-/* In: none
-/* Out: value of zmco register
-/* Description: determines how many times chip has been
-/* permanently written to. 
-/*******************************************************/
+  Method: getBurnCount
+  In: none
+  Out: value of zmco register
+  Description: determines how many times chip has been
+  permanently written to. 
+*******************************************************/
 int AMS_5600::getBurnCount()
 {
   return readOneByte(_zmco);
 }
 
 /*******************************************************
-/* Method: burnAngle
-/* In: none
-/* Out: 1 success
-/*     -1 no magnet
-/*     -2 burn limit exceeded
-/*     -3 start and end positions not set (useless burn)
-/* Description: burns start and end positions to chip.
-/* THIS CAN ONLY BE DONE 3 TIMES
-/*******************************************************/
+  Method: burnAngle
+  In: none
+  Out: 1 success
+      -1 no magnet
+      -2 burn limit exceeded
+      -3 start and end positions not set (useless burn)
+  Description: burns start and end positions to chip.
+  THIS CAN ONLY BE DONE 3 TIMES
+*******************************************************/
 int AMS_5600::burnAngle()
 {
   int retVal = 1;
   _zPosition = getStartPosition();
   _mPosition = getEndPosition();
-  _maxAngle  = getMaxAngle();
-  
-  if(detectMagnet() == 1)
+  _maxAngle = getMaxAngle();
+
+  if (detectMagnet() == 1)
   {
-    if(getBurnCount() < 3)
+    if (getBurnCount() < 3)
     {
-      if((_zPosition == 0)&&(_mPosition ==0))
+      if ((_zPosition == 0) && (_mPosition == 0))
         retVal = -3;
       else
         writeOneByte(_burn, 0x80);
     }
     else
       retVal = -2;
-  } 
+  }
   else
     retVal = -1;
-    
+
   return retVal;
 }
 
 /*******************************************************
-/* Method: burnMaxAngleAndConfig
-/* In: none
-/* Out: 1 success
-/*     -1 burn limit exceeded
-/*     -2 max angle is to small, must be at or above 18 degrees
-/* Description: burns max angle and config data to chip.
-/* THIS CAN ONLY BE DONE 1 TIME
-/*******************************************************/
+  Method: burnMaxAngleAndConfig
+  In: none
+  Out: 1 success
+      -1 burn limit exceeded
+      -2 max angle is to small, must be at or above 18 degrees
+  Description: burns max angle and config data to chip.
+  THIS CAN ONLY BE DONE 1 TIME
+*******************************************************/
 int AMS_5600::burnMaxAngleAndConfig()
 {
   int retVal = 1;
-  _maxAngle  = getMaxAngle();
-  
-  if(getBurnCount() ==0)
+  _maxAngle = getMaxAngle();
+
+  if (getBurnCount() == 0)
   {
-    if(_maxAngle*0.087 < 18)
+    if (_maxAngle * 0.087 < 18)
       retVal = -2;
     else
-      writeOneByte(_burn, 0x40);    
-  }  
+      writeOneByte(_burn, 0x40);
+  }
   else
     retVal = -1;
-    
+
   return retVal;
 }
 
-
 /*******************************************************
-/* Method: readOneByte
-/* In: register to read
-/* Out: data read from i2c
-/* Description: reads one byte register from i2c
-/*******************************************************/
+  Method: readOneByte
+  In: register to read
+  Out: data read from i2c
+  Description: reads one byte register from i2c
+*******************************************************/
 int AMS_5600::readOneByte(int in_adr)
 {
   int retVal = -1;
@@ -370,56 +372,59 @@ int AMS_5600::readOneByte(int in_adr)
   Wire.write(in_adr);
   Wire.endTransmission();
   Wire.requestFrom(_ams5600_Address, 1);
-  while(Wire.available() == 0);
+  while (Wire.available() == 0)
+    ;
   retVal = Wire.read();
-  
+
   return retVal;
 }
 
 /*******************************************************
-/* Method: readTwoBytes
-/* In: two registers to read
-/* Out: data read from i2c as a word
-/* Description: reads two bytes register from i2c
-/*******************************************************/
+  Method: readTwoBytes
+  In: two registers to read
+  Out: data read from i2c as a word
+  Description: reads two bytes register from i2c
+*******************************************************/
 word AMS_5600::readTwoBytes(int in_adr_hi, int in_adr_lo)
 {
   word retVal = -1;
- 
+
   /* Read Low Byte */
   Wire.beginTransmission(_ams5600_Address);
   Wire.write(in_adr_lo);
   Wire.endTransmission();
   Wire.requestFrom(_ams5600_Address, 1);
-  while(Wire.available() == 0);
+  while (Wire.available() == 0)
+    ;
   int low = Wire.read();
- 
-  /* Read High Byte */  
+
+  /* Read High Byte */
   Wire.beginTransmission(_ams5600_Address);
   Wire.write(in_adr_hi);
   Wire.endTransmission();
   Wire.requestFrom(_ams5600_Address, 1);
-  
-  while(Wire.available() == 0);
-  
+
+  while (Wire.available() == 0)
+    ;
+
   word high = Wire.read();
-  
+
   high = high << 8;
   retVal = high | low;
-  
+
   return retVal;
 }
 
 /*******************************************************
-/* Method: writeOneByte
-/* In: address and data to write
-/* Out: none
-/* Description: writes one byte to a i2c register
-/*******************************************************/
+  Method: writeOneByte
+  In: address and data to write
+  Out: none
+  Description: writes one byte to a i2c register
+*******************************************************/
 void AMS_5600::writeOneByte(int adr_in, int dat_in)
 {
   Wire.beginTransmission(_ams5600_Address);
-  Wire.write(adr_in); 
+  Wire.write(adr_in);
   Wire.write(dat_in);
   Wire.endTransmission();
 }

--- a/src/AS5600.h
+++ b/src/AS5600.h
@@ -1,16 +1,15 @@
 
 /****************************************************
-/* AMS 5600 class for Arduino platform
-/* Author: Tom Denton
-/* Date: 15 Dec 2014
-/* File: AMS_5600.h 
-/* Version 1.00
-/* www.ams.com
-/*  
-/* Description:  This class has been designed to
-/* access the AMS 5600 “potuino” shield.
-/*
-/***************************************************/
+  AMS 5600 class for Arduino platform
+  Author: Tom Denton
+  Date: 15 Dec 2014
+  File: AMS_5600.h 
+  Version 1.00
+  www.ams.com
+   
+  Description:  This class has been designed to
+  access the AMS 5600 “potuino” shield.
+***************************************************/
 
 #ifndef AMS_5600_h
 #define AMS_5600_h
@@ -19,67 +18,63 @@
 
 class AMS_5600
 {
-  public:
-    
-    AMS_5600(void);
-    int getAddress();       
-    
-    word setMaxAngle(word newMaxAngle = -1);
-    word getMaxAngle();
-    
-    word setStartPosition(word startAngle = -1);
-    word getStartPosition();
-    
-    word setEndPosition(word endAngle = -1);
-    word getEndPosition();
-    
-    word getRawAngle();
-    word getScaledAngle();
-    
-    int  detectMagnet();
-    int  getMagnetStrength();
-    int  getAgc();
-    word getMagnitude();
-    
-    int  getBurnCount();
-    int  burnAngle();
-    int  burnMaxAngleAndConfig();
-    void setOutPut(uint8_t mode);
-    
-  private:
-  
-    int _ams5600_Address;
-      
-    word _rawStartAngle;
-    word _zPosition;
-    word _rawEndAngle;
-    word _mPosition;
-    word _maxAngle;
-    
-    /* Registers */
-    int _zmco;
-    int _zpos_hi;    /*zpos[11:8] high nibble  START POSITION */
-    int _zpos_lo;    /*zpos[7:0] */
-    int _mpos_hi;    /*mpos[11:8] high nibble  STOP POSITION */
-    int _mpos_lo;    /*mpos[7:0] */
-    int _mang_hi;    /*mang[11:8] high nibble  MAXIMUM ANGLE */
-    int _mang_lo;    /*mang[7:0] */
-    int _conf_hi;    
-    int _conf_lo;
-    int _raw_ang_hi;
-    int _raw_ang_lo;
-    int _ang_hi;
-    int _ang_lo;
-    int _stat;
-    int _agc;
-    int _mag_hi;
-    int _mag_lo;
-    int _burn;
-    
-    int readOneByte(int in_adr);
-    word readTwoBytes(int in_adr_hi, int in_adr_lo);
-    void writeOneByte(int adr_in, int dat_in);
+public:
+  AMS_5600(void);
+  int getAddress();
 
-   
+  word setMaxAngle(word newMaxAngle = -1);
+  word getMaxAngle();
+
+  word setStartPosition(word startAngle = -1);
+  word getStartPosition();
+
+  word setEndPosition(word endAngle = -1);
+  word getEndPosition();
+
+  word getRawAngle();
+  word getScaledAngle();
+
+  int detectMagnet();
+  int getMagnetStrength();
+  int getAgc();
+  word getMagnitude();
+
+  int getBurnCount();
+  int burnAngle();
+  int burnMaxAngleAndConfig();
+  void setOutPut(uint8_t mode);
+
+private:
+  int _ams5600_Address;
+
+  word _rawStartAngle;
+  word _zPosition;
+  word _rawEndAngle;
+  word _mPosition;
+  word _maxAngle;
+
+  /* Registers */
+  int _zmco;
+  int _zpos_hi; /*zpos[11:8] high nibble  START POSITION */
+  int _zpos_lo; /*zpos[7:0] */
+  int _mpos_hi; /*mpos[11:8] high nibble  STOP POSITION */
+  int _mpos_lo; /*mpos[7:0] */
+  int _mang_hi; /*mang[11:8] high nibble  MAXIMUM ANGLE */
+  int _mang_lo; /*mang[7:0] */
+  int _conf_hi;
+  int _conf_lo;
+  int _raw_ang_hi;
+  int _raw_ang_lo;
+  int _ang_hi;
+  int _ang_lo;
+  int _stat;
+  int _agc;
+  int _mag_hi;
+  int _mag_lo;
+  int _burn;
+
+  int readOneByte(int in_adr);
+  word readTwoBytes(int in_adr_hi, int in_adr_lo);
+  void writeOneByte(int adr_in, int dat_in);
 };
 #endif


### PR DESCRIPTION
I used PlatformIO and I was getting a load of warnings that were caused by the leading `/*` chars in comment blocks. I removed them. Ignore this PR if that's how you wish to format the blocks and I will continue to use my fork.

Love your library though 👍 