### PR TITLE
Removed unnecessary line

### DIFF
--- a/examples/readAngle/readAngle.ino
+++ b/examples/readAngle/readAngle.ino
@@ -42,8 +42,7 @@ float convertRawAngleToDegrees(word newAngle)
 {
   /* Raw data reports 0 - 4095 segments, which is 0.087 of a degree */
   float retVal = newAngle * 0.087;
-  ang = retVal;
-  return ang;
+  return retVal;
 }
 void loop()
 {


### PR DESCRIPTION
removed double handling of return value which was causing loss of resolution to the nearest whole degree
`ang` is implicitly cast to float but had undesired behaviour