### PR TITLE
fixed readTwoBytes() and register addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ]
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,14 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino

--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -35,7 +35,7 @@ AMS_5600::AMS_5600()
 
   _addr_zpos    = 0x01; // 0x02 - LSB
   _addr_mpos    = 0x03; // 0x04 - LSB
-  _addr_mang     = 0x05; // 0x06 - LSB
+  _addr_mang    = 0x05; // 0x06 - LSB
   _addr_conf    = 0x07; // 0x08 - LSB
   _addr_raw_ang = 0x0c; // 0x0d - LSB
   _addr_ang     = 0x0e; // 0x0f - LSB

--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -421,32 +421,17 @@ int AMS_5600::readOneByte(int in_adr)
 *******************************************************/
 word AMS_5600::readTwoBytes(int in_adr_hi, int in_adr_lo)
 {
-  word retVal = -1;
-
-  /* Read Low Byte */
-  Wire.beginTransmission(_ams5600_Address);
-  Wire.write(in_adr_lo);
-  Wire.endTransmission();
-  Wire.requestFrom(_ams5600_Address, 1);
-  while (Wire.available() == 0)
-    ;
-  int low = Wire.read();
-  
-  /* Read High Byte */
+  /* Read 2 Bytes */
   Wire.beginTransmission(_ams5600_Address);
   Wire.write(in_adr_hi);
   Wire.endTransmission();
-  Wire.requestFrom(_ams5600_Address, 1);
-
-  while (Wire.available() == 0)
+  Wire.requestFrom(_ams5600_Address, 2);
+  while (Wire.available() < 2)
     ;
-
-  word high = Wire.read();
   
-  high = high << 8;
-  retVal = high | low;
-
-  return retVal;
+  int high = Wire.read();
+  int low = Wire.read();
+  return ( high << 8 ) | low;
 }
 
 /*******************************************************

--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -29,27 +29,23 @@ AMS_5600::AMS_5600()
   /* load register values */
   /* c++ class forbids pre loading of variables */
   _zmco = 0x00;
-  _zpos_hi = 0x01;
-  _zpos_lo = 0x02;
-  _mpos_hi = 0x03;
-  _mpos_lo = 0x04;
-  _mang_hi = 0x05;
-  _mang_lo = 0x06;
-  _conf_hi = 0x07;
-  _conf_lo = 0x08;
-  _raw_ang_hi = 0x0c;
-  _raw_ang_lo = 0x0d;
-  _ang_hi = 0x0e;
-  _ang_lo = 0x0f;
   _stat = 0x0b;
   _agc = 0x1a;
-  _mag_hi = 0x1b;
-  _mag_lo = 0x1c;
   _burn = 0xff;
+
+  _addr_zpos    = 0x01; // 0x02 - LSB
+  _addr_mpos    = 0x03; // 0x04 - LSB
+  _addr_mang     = 0x05; // 0x06 - LSB
+  _addr_conf    = 0x07; // 0x08 - LSB
+  _addr_raw_ang = 0x0c; // 0x0d - LSB
+  _addr_ang     = 0x0e; // 0x0f - LSB
+  _addr_mag     = 0x1b; // 0x1c - LSB
 }
+
 /* mode = 0, output PWM, mode = 1 output analog (full range from 0% to 100% between GND and VDD */
 void AMS_5600::setOutPut(uint8_t mode)
 {
+  int _conf_lo = _addr_conf+1; // lower byte address
   uint8_t config_status;
   config_status = readOneByte(_conf_lo);
   if (mode == 1)
@@ -71,6 +67,7 @@ void AMS_5600::setOutPut(uint8_t mode)
     writeOneByte(_conf_lo, lowByte(config_status));
   }
 }
+
 /****************************************************
   Method: AMS_5600
   In: none
@@ -101,12 +98,12 @@ word AMS_5600::setMaxAngle(word newMaxAngle)
   else
     _maxAngle = newMaxAngle;
 
-  writeOneByte(_mang_hi, highByte(_maxAngle));
+  writeOneByte(_addr_mang, highByte(_maxAngle));
   delay(2);
-  writeOneByte(_mang_lo, lowByte(_maxAngle));
+  writeOneByte(_addr_mang+1, lowByte(_maxAngle));
   delay(2);
 
-  retVal = readTwoBytes(_mang_hi, _mang_lo);
+  retVal = readTwoBytes(_addr_mang);
   return retVal;
 }
 
@@ -118,7 +115,7 @@ word AMS_5600::setMaxAngle(word newMaxAngle)
 *******************************************************/
 word AMS_5600::getMaxAngle()
 {
-  return readTwoBytes(_mang_hi, _mang_lo);
+  return readTwoBytes(_addr_mang);
 }
 
 /*******************************************************
@@ -138,11 +135,11 @@ word AMS_5600::setStartPosition(word startAngle)
   else
     _rawStartAngle = startAngle;
 
-  writeOneByte(_zpos_hi, highByte(_rawStartAngle));
+  writeOneByte(_addr_zpos, highByte(_rawStartAngle));
   delay(2);
-  writeOneByte(_zpos_lo, lowByte(_rawStartAngle));
+  writeOneByte(_addr_zpos+1, lowByte(_rawStartAngle));
   delay(2);
-  _zPosition = readTwoBytes(_zpos_hi, _zpos_lo);
+  _zPosition = readTwoBytes(_addr_zpos);
 
   return (_zPosition);
 }
@@ -155,7 +152,7 @@ word AMS_5600::setStartPosition(word startAngle)
 *******************************************************/
 word AMS_5600::getStartPosition()
 {
-  return readTwoBytes(_zpos_hi, _zpos_lo);
+  return readTwoBytes(_addr_zpos);
 }
 
 /*******************************************************
@@ -173,11 +170,11 @@ word AMS_5600::setEndPosition(word endAngle)
   else
     _rawEndAngle = endAngle;
 
-  writeOneByte(_mpos_hi, highByte(_rawEndAngle));
+  writeOneByte(_addr_mpos, highByte(_rawEndAngle));
   delay(2);
-  writeOneByte(_mpos_lo, lowByte(_rawEndAngle));
+  writeOneByte(_addr_mpos+1, lowByte(_rawEndAngle));
   delay(2);
-  _mPosition = readTwoBytes(_mpos_hi, _mpos_lo);
+  _mPosition = readTwoBytes(_addr_mpos);
 
   return (_mPosition);
 }
@@ -190,7 +187,7 @@ word AMS_5600::setEndPosition(word endAngle)
 *******************************************************/
 word AMS_5600::getEndPosition()
 {
-  word retVal = readTwoBytes(_mpos_hi, _mpos_lo);
+  word retVal = readTwoBytes(_addr_mpos);
   return retVal;
 }
 
@@ -203,7 +200,7 @@ word AMS_5600::getEndPosition()
 *******************************************************/
 word AMS_5600::getRawAngle()
 {
-  return readTwoBytes(_raw_ang_hi, _raw_ang_lo);
+  return readTwoBytes(_addr_raw_ang);
 }
 
 /*******************************************************
@@ -216,7 +213,7 @@ word AMS_5600::getRawAngle()
 *******************************************************/
 word AMS_5600::getScaledAngle()
 {
-  return readTwoBytes(_ang_hi, _ang_lo);
+  return readTwoBytes(_addr_ang);
 }
 
 /*******************************************************
@@ -291,7 +288,7 @@ int AMS_5600::getAgc()
 *******************************************************/
 word AMS_5600::getMagnitude()
 {
-  return readTwoBytes(_mag_hi, _mag_lo);
+  return readTwoBytes(_addr_mag);
 }
 
 /*******************************************************
@@ -302,7 +299,7 @@ word AMS_5600::getMagnitude()
 *******************************************************/
 word AMS_5600::getConf()
 {
-  return readTwoBytes(_conf_hi, _conf_lo);
+  return readTwoBytes(_addr_conf);
 }
 
 /*******************************************************
@@ -313,9 +310,9 @@ word AMS_5600::getConf()
 *******************************************************/
 void AMS_5600::setConf(word _conf)
 {
-  writeOneByte(_conf_hi, highByte(_conf));
+  writeOneByte(_addr_conf, highByte(_conf));
   delay(2);
-  writeOneByte(_conf_lo, lowByte(_conf));
+  writeOneByte(_addr_conf+1, lowByte(_conf));
   delay(2);
 }
 
@@ -419,11 +416,11 @@ int AMS_5600::readOneByte(int in_adr)
   Out: data read from i2c as a word
   Description: reads two bytes register from i2c
 *******************************************************/
-word AMS_5600::readTwoBytes(int in_adr_hi, int in_adr_lo)
+word AMS_5600::readTwoBytes(int addr_in)
 {
   /* Read 2 Bytes */
   Wire.beginTransmission(_ams5600_Address);
-  Wire.write(in_adr_hi);
+  Wire.write(addr_in);
   Wire.endTransmission();
   Wire.requestFrom(_ams5600_Address, 2);
   while (Wire.available() < 2)

--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -11,6 +11,10 @@
   access the AMS 5600 “potuino” shield.
 *****************************************************/
 
+// updated jan 2022 by isc - read two bytes together
+
+// datasheet: https://ams.com/documents/20143/36005/AS5600_DS000365_5-00.pdf
+
 #include "Arduino.h"
 #include "AS5600.h"
 #include "Wire.h"
@@ -28,18 +32,18 @@ AMS_5600::AMS_5600()
 
   /* load register values */
   /* c++ class forbids pre loading of variables */
-  _zmco = 0x00;
-  _stat = 0x0b;
-  _agc = 0x1a;
-  _burn = 0xff;
+  _addr_zmco   = 0x00;
+  _addr_status = 0x0b;
+  _addr_agc    = 0x1a;
+  _addr_burn   = 0xff;
 
-  _addr_zpos    = 0x01; // 0x02 - LSB
-  _addr_mpos    = 0x03; // 0x04 - LSB
-  _addr_mang    = 0x05; // 0x06 - LSB
-  _addr_conf    = 0x07; // 0x08 - LSB
-  _addr_raw_ang = 0x0c; // 0x0d - LSB
-  _addr_ang     = 0x0e; // 0x0f - LSB
-  _addr_mag     = 0x1b; // 0x1c - LSB
+  _addr_zpos      = 0x01; // 0x02 - lower byte
+  _addr_mpos      = 0x03; // 0x04 - lower byte
+  _addr_mang      = 0x05; // 0x06 - lower byte
+  _addr_conf      = 0x07; // 0x08 - lower byte
+  _addr_raw_angle = 0x0c; // 0x0d - lower byte
+  _addr_angle     = 0x0e; // 0x0f - lower byte
+  _addr_magnitude = 0x1b; // 0x1c - lower byte
 }
 
 /* mode = 0, output PWM, mode = 1 output analog (full range from 0% to 100% between GND and VDD */
@@ -48,22 +52,15 @@ void AMS_5600::setOutPut(uint8_t mode)
   int _conf_lo = _addr_conf+1; // lower byte address
   uint8_t config_status;
   config_status = readOneByte(_conf_lo);
-  if (mode == 1)
-  {
+  if (mode == 1) {
     config_status = config_status & 0xcf;
-  }
-  else
-  {
+  } else {
     uint8_t config_status;
     config_status = readOneByte(_conf_lo);
     if (mode == 1)
-    {
       config_status = config_status & 0xcf;
-    }
     else
-    {
       config_status = config_status & 0xef;
-    }
     writeOneByte(_conf_lo, lowByte(config_status));
   }
 }
@@ -92,9 +89,7 @@ word AMS_5600::setMaxAngle(word newMaxAngle)
 {
   word retVal;
   if (newMaxAngle == -1)
-  {
     _maxAngle = getRawAngle();
-  }
   else
     _maxAngle = newMaxAngle;
 
@@ -103,7 +98,7 @@ word AMS_5600::setMaxAngle(word newMaxAngle)
   writeOneByte(_addr_mang+1, lowByte(_maxAngle));
   delay(2);
 
-  retVal = readTwoBytes(_addr_mang);
+  retVal = readTwoBytesSeparately(_addr_mang);
   return retVal;
 }
 
@@ -115,7 +110,7 @@ word AMS_5600::setMaxAngle(word newMaxAngle)
 *******************************************************/
 word AMS_5600::getMaxAngle()
 {
-  return readTwoBytes(_addr_mang);
+  return readTwoBytesSeparately(_addr_mang);
 }
 
 /*******************************************************
@@ -129,9 +124,7 @@ word AMS_5600::getMaxAngle()
 word AMS_5600::setStartPosition(word startAngle)
 {
   if (startAngle == -1)
-  {
     _rawStartAngle = getRawAngle();
-  }
   else
     _rawStartAngle = startAngle;
 
@@ -139,7 +132,7 @@ word AMS_5600::setStartPosition(word startAngle)
   delay(2);
   writeOneByte(_addr_zpos+1, lowByte(_rawStartAngle));
   delay(2);
-  _zPosition = readTwoBytes(_addr_zpos);
+  _zPosition = readTwoBytesSeparately(_addr_zpos);
 
   return (_zPosition);
 }
@@ -152,7 +145,7 @@ word AMS_5600::setStartPosition(word startAngle)
 *******************************************************/
 word AMS_5600::getStartPosition()
 {
-  return readTwoBytes(_addr_zpos);
+  return readTwoBytesSeparately(_addr_zpos);
 }
 
 /*******************************************************
@@ -174,7 +167,7 @@ word AMS_5600::setEndPosition(word endAngle)
   delay(2);
   writeOneByte(_addr_mpos+1, lowByte(_rawEndAngle));
   delay(2);
-  _mPosition = readTwoBytes(_addr_mpos);
+  _mPosition = readTwoBytesSeparately(_addr_mpos);
 
   return (_mPosition);
 }
@@ -187,7 +180,7 @@ word AMS_5600::setEndPosition(word endAngle)
 *******************************************************/
 word AMS_5600::getEndPosition()
 {
-  word retVal = readTwoBytes(_addr_mpos);
+  word retVal = readTwoBytesSeparately(_addr_mpos);
   return retVal;
 }
 
@@ -200,7 +193,7 @@ word AMS_5600::getEndPosition()
 *******************************************************/
 word AMS_5600::getRawAngle()
 {
-  return readTwoBytes(_addr_raw_ang);
+  return readTwoBytesTogether(_addr_raw_angle);
 }
 
 /*******************************************************
@@ -213,7 +206,7 @@ word AMS_5600::getRawAngle()
 *******************************************************/
 word AMS_5600::getScaledAngle()
 {
-  return readTwoBytes(_addr_ang);
+  return readTwoBytesTogether(_addr_angle);
 }
 
 /*******************************************************
@@ -231,7 +224,7 @@ int AMS_5600::detectMagnet()
   /* MD high = magnet detected*/
   /* ML high = AGC Maximum overflow, magnet to weak*/
   /* MH high = AGC minimum overflow, Magnet to strong*/
-  magStatus = readOneByte(_stat);
+  magStatus = readOneByte(_addr_status);
 
   if (magStatus & 0x20)
     retVal = 1;
@@ -256,14 +249,13 @@ int AMS_5600::getMagnetStrength()
   /* MD high = magnet detected */
   /* ML high = AGC Maximum overflow, magnet to weak*/
   /* MH high = AGC minimum overflow, Magnet to strong*/
-  magStatus = readOneByte(_stat);
-  if (detectMagnet() == 1)
-  {
-    retVal = 2; /*just right */
+  magStatus = readOneByte(_addr_status);
+  if (detectMagnet() == 1) {
+    retVal = 2; /* just right */
     if (magStatus & 0x10)
-      retVal = 1; /*to weak */
+      retVal = 1; /* too weak */
     else if (magStatus & 0x08)
-      retVal = 3; /*to strong */
+      retVal = 3; /* too strong */
   }
 
   return retVal;
@@ -277,7 +269,7 @@ int AMS_5600::getMagnetStrength()
 *******************************************************/
 int AMS_5600::getAgc()
 {
-  return readOneByte(_agc);
+  return readOneByte(_addr_agc);
 }
 
 /*******************************************************
@@ -288,7 +280,7 @@ int AMS_5600::getAgc()
 *******************************************************/
 word AMS_5600::getMagnitude()
 {
-  return readTwoBytes(_addr_mag);
+  return readTwoBytesTogether(_addr_magnitude);
 }
 
 /*******************************************************
@@ -299,7 +291,7 @@ word AMS_5600::getMagnitude()
 *******************************************************/
 word AMS_5600::getConf()
 {
-  return readTwoBytes(_addr_conf);
+  return readTwoBytesSeparately(_addr_conf);
 }
 
 /*******************************************************
@@ -325,7 +317,7 @@ void AMS_5600::setConf(word _conf)
 *******************************************************/
 int AMS_5600::getBurnCount()
 {
-  return readOneByte(_zmco);
+  return readOneByte(_addr_zmco);
 }
 
 /*******************************************************
@@ -345,19 +337,16 @@ int AMS_5600::burnAngle()
   _mPosition = getEndPosition();
   _maxAngle = getMaxAngle();
 
-  if (detectMagnet() == 1)
-  {
-    if (getBurnCount() < 3)
-    {
+  if (detectMagnet() == 1) {
+    if (getBurnCount() < 3) {
       if ((_zPosition == 0) && (_mPosition == 0))
         retVal = -3;
       else
-        writeOneByte(_burn, 0x80);
+        writeOneByte(_addr_burn, 0x80);
     }
     else
       retVal = -2;
-  }
-  else
+  } else
     retVal = -1;
 
   return retVal;
@@ -377,12 +366,11 @@ int AMS_5600::burnMaxAngleAndConfig()
   int retVal = 1;
   _maxAngle = getMaxAngle();
 
-  if (getBurnCount() == 0)
-  {
+  if (getBurnCount() == 0) {
     if (_maxAngle * 0.087 < 18)
       retVal = -2;
     else
-      writeOneByte(_burn, 0x40);
+      writeOneByte(_addr_burn, 0x40);
   }
   else
     retVal = -1;
@@ -416,8 +404,27 @@ int AMS_5600::readOneByte(int in_adr)
   Out: data read from i2c as a word
   Description: reads two bytes register from i2c
 *******************************************************/
-word AMS_5600::readTwoBytes(int addr_in)
+word AMS_5600::readTwoBytesTogether(int addr_in)
 {
+
+  // use only for Angle, Raw Angle and Magnitude
+
+  // read 2 bytes together to prevent getting inconsistent
+  //    data while the encoder is moving
+  // according to the datasheet the address is automatically incremented
+  //    but only for Angle, Raw Angle and Magnitude
+  // the title says it's auto, but the paragraph after it
+  //    says it does NOT
+  // tested and it does auto increment
+  
+  // PAGE 13: https://ams.com/documents/20143/36005/AS5600_DS000365_5-00.pdf
+  // Automatic Increment of the Address Pointer for ANGLE, RAW ANGLE and MAGNITUDE Registers
+  // These are special registers which suppress the automatic
+  // increment of the address pointer on reads, so a re-read of these
+  // registers requires no I²C write command to reload the address
+  // pointer. This special treatment of the pointer is effective only if
+  // the address pointer is set to the high byte of the register.
+
   /* Read 2 Bytes */
   Wire.beginTransmission(_ams5600_Address);
   Wire.write(addr_in);
@@ -426,9 +433,29 @@ word AMS_5600::readTwoBytes(int addr_in)
   while (Wire.available() < 2)
     ;
   
-  int high = Wire.read();
-  int low = Wire.read();
-  return ( high << 8 ) | low;
+  int highByte = Wire.read();
+  int lowByte  = Wire.read();
+
+  // in case newer version of IC used the same address to
+  //    store something else, get only the 3 bits
+  //return ( ( highByte & 0b111 ) << 8 ) | lowByte;
+
+  // but in case newer version has higher resolution
+  //    we're good to go
+  return ( highByte << 8 ) | lowByte;
+}
+
+/*******************************************************
+  Method: readTwoBytes
+  In: two registers to read
+  Out: data read from i2c as a word
+  Description: reads two bytes register from i2c
+*******************************************************/
+word AMS_5600::readTwoBytesSeparately(int addr_in)
+{
+  int highByte = readOneByte(addr_in  );
+  int lowByte  = readOneByte(addr_in+1);
+  return ( highByte << 8 ) | lowByte;
 }
 
 /*******************************************************

--- a/src/AS5600.h
+++ b/src/AS5600.h
@@ -57,26 +57,23 @@ private:
 
   /* Registers */
   int _zmco;
-  int _zpos_hi; /*zpos[11:8] high nibble  START POSITION */
-  int _zpos_lo; /*zpos[7:0] */
-  int _mpos_hi; /*mpos[11:8] high nibble  STOP POSITION */
-  int _mpos_lo; /*mpos[7:0] */
-  int _mang_hi; /*mang[11:8] high nibble  MAXIMUM ANGLE */
-  int _mang_lo; /*mang[7:0] */
-  int _conf_hi;
-  int _conf_lo;
-  int _raw_ang_hi;
-  int _raw_ang_lo;
-  int _ang_hi;
-  int _ang_lo;
   int _stat;
   int _agc;
-  int _mag_hi;
-  int _mag_lo;
   int _burn;
 
+  // specify starting address
+  // addr   = upper byte of data
+  // addr+1 = lower byte of data
+  int _addr_zpos; // only bits 0:3 of upper byte is used
+  int _addr_mpos; // only bits 0:3 of upper byte is used
+  int _addr_mang;  // only bits 0:3 of upper byte is used
+  int _addr_conf;
+  int _addr_raw_ang;
+  int _addr_ang;
+  int _addr_mag;
+
   int readOneByte(int in_adr);
-  word readTwoBytes(int in_adr_hi, int in_adr_lo);
+  word readTwoBytes(int addr_in);
   void writeOneByte(int adr_in, int dat_in);
 };
 #endif

--- a/src/AS5600.h
+++ b/src/AS5600.h
@@ -11,6 +11,10 @@
   access the AMS 5600 “potuino” shield.
 ***************************************************/
 
+// updated jan 2022 by isc - read two bytes together
+
+// datasheet: https://ams.com/documents/20143/36005/AS5600_DS000365_5-00.pdf
+
 #ifndef AMS_5600_h
 #define AMS_5600_h
 
@@ -55,25 +59,28 @@ private:
   word _mPosition;
   word _maxAngle;
 
-  /* Registers */
-  int _zmco;
-  int _stat;
-  int _agc;
-  int _burn;
+  // single byte registers
+  int _addr_status; // magnet status
+  int _addr_agc;    // automatic gain control
+  int _addr_burn;   // permanent burning of configs (zpos, mpos, mang, conf)
+  int _addr_zmco;   // number of times zpos/mpos has been permanently burned
+                    // zpos/mpos can be permanently burned 3x
+                    // mang/conf can be burned only once
 
-  // specify starting address
-  // addr   = upper byte of data
-  // addr+1 = lower byte of data
-  int _addr_zpos;    // only bits 0:3 of upper byte is used
-  int _addr_mpos;    // only bits 0:3 of upper byte is used
-  int _addr_mang;    // only bits 0:3 of upper byte is used
-  int _addr_conf;
-  int _addr_raw_ang;
-  int _addr_ang;
-  int _addr_mag;
+  // double byte registers, specify starting address (lower addr, but higher byte data)
+  // addr   = upper byte of data (MSB), only bits 0:3 are used
+  // addr+1 = lower byte of data (LSB)
+  int _addr_zpos;      // zero position (start)
+  int _addr_mpos;      // maximum position (stop)
+  int _addr_mang;      // maximum angle
+  int _addr_conf;      // configuration
+  int _addr_raw_angle; // raw angle
+  int _addr_angle;     // mapped angle
+  int _addr_magnitude; // magnitude of internal CORDIC
 
   int readOneByte(int in_adr);
-  word readTwoBytes(int addr_in);
+  word readTwoBytesSeparately(int addr_in);
+  word readTwoBytesTogether(int addr_in);
   void writeOneByte(int adr_in, int dat_in);
 };
 #endif

--- a/src/AS5600.h
+++ b/src/AS5600.h
@@ -64,9 +64,9 @@ private:
   // specify starting address
   // addr   = upper byte of data
   // addr+1 = lower byte of data
-  int _addr_zpos; // only bits 0:3 of upper byte is used
-  int _addr_mpos; // only bits 0:3 of upper byte is used
-  int _addr_mang;  // only bits 0:3 of upper byte is used
+  int _addr_zpos;    // only bits 0:3 of upper byte is used
+  int _addr_mpos;    // only bits 0:3 of upper byte is used
+  int _addr_mang;    // only bits 0:3 of upper byte is used
   int _addr_conf;
   int _addr_raw_ang;
   int _addr_ang;


### PR DESCRIPTION
Made the following changes:
- Changed readTwoBytes( addrA, addrB ) to readTwoBytes( addrA )
  AddrB is not used anymore. If for whatever reason, a user goes:
  readTwoBytes( magnetStatusAddr, agcAddr ), they will get the wrong result,
- Cleaned register addresses, made it match name on datasheet.
- CRITICAL: Made 2 versions of readTwoBytes()

   (1) reads both bytes together (used by Raw Angle, Angle, Magnitude)
   (2) read each byte separately (used by zpos, mpos, mang, conf)

   Because as per datasheet, read 2 bytes together only applies to Raw Angle, Angle and Magnitude,
   those that can dynamically change while in operation.
   Tested for all 3 and it works.

   I don't have a spare device, so could not test if for: zpos, mpos, mang and conf
   Maintained the previous method of separately reading them to be sure.
   If someone has a programmed device and can confirm (1) works,
   then (2) can be removed.