### PR TITLE
updated reading 2 bytes. cleaned address.

### DIFF
--- a/src/AS5600.h
+++ b/src/AS5600.h
@@ -11,6 +11,10 @@
   access the AMS 5600 “potuino” shield.
 ***************************************************/
 
+// updated jan 2022 by isc - read two bytes together
+
+// datasheet: https://ams.com/documents/20143/36005/AS5600_DS000365_5-00.pdf
+
 #ifndef AMS_5600_h
 #define AMS_5600_h
 
@@ -19,6 +23,7 @@
 class AMS_5600
 {
 public:
+
   AMS_5600(void);
   int getAddress();
 
@@ -47,36 +52,40 @@ public:
   void setOutPut(uint8_t mode);
 
 private:
-  int _ams5600_Address;
 
-  word _rawStartAngle;
-  word _zPosition;
-  word _rawEndAngle;
-  word _mPosition;
-  word _maxAngle;
-
-  /* Registers */
-  int _zmco;
-  int _zpos_hi; /*zpos[11:8] high nibble  START POSITION */
-  int _zpos_lo; /*zpos[7:0] */
-  int _mpos_hi; /*mpos[11:8] high nibble  STOP POSITION */
-  int _mpos_lo; /*mpos[7:0] */
-  int _mang_hi; /*mang[11:8] high nibble  MAXIMUM ANGLE */
-  int _mang_lo; /*mang[7:0] */
-  int _conf_hi;
-  int _conf_lo;
-  int _raw_ang_hi;
-  int _raw_ang_lo;
-  int _ang_hi;
-  int _ang_lo;
-  int _stat;
-  int _agc;
-  int _mag_hi;
-  int _mag_lo;
-  int _burn;
+  // i2c address
+  static const uint8_t _ams5600_Address = 0x36;
+  
+  // single byte registers
+  static const uint8_t _addr_status = 0x0b; // magnet status
+  static const uint8_t _addr_agc    = 0x1a; // automatic gain control
+  static const uint8_t _addr_burn   = 0xff; // permanent burning of configs (zpos, mpos, mang, conf)
+  static const uint8_t _addr_zmco   = 0x00; // number of times zpos/mpos has been permanently burned
+                                            // zpos/mpos can be permanently burned 3x
+                                            // mang/conf can be burned only once
+  
+  // double byte registers, specify starting address (lower addr, but higher byte data)
+  // addr   = upper byte of data (MSB), only bits 0:3 are used
+  // addr+1 = lower byte of data (LSB)
+  static const uint8_t _addr_zpos      = 0x01; // zero position (start)
+                                               // 0x02 - lower byte
+  static const uint8_t _addr_mpos      = 0x03; // maximum position (stop)
+                                               // 0x04 - lower byte
+  static const uint8_t _addr_mang      = 0x05; // maximum angle
+                                               // 0x06 - lower byte
+  static const uint8_t _addr_conf      = 0x07; // configuration
+                                               // 0x08 - lower byte
+  static const uint8_t _addr_raw_angle = 0x0c; // raw angle
+                                               // 0x0d - lower byte
+  static const uint8_t _addr_angle     = 0x0e; // mapped angle
+                                               // 0x0f - lower byte
+  static const uint8_t _addr_magnitude = 0x1b; // magnitude of internal CORDIC
+                                               // 0x1c - lower byte
 
   int readOneByte(int in_adr);
-  word readTwoBytes(int in_adr_hi, int in_adr_lo);
+  word readTwoBytesSeparately(int addr_in);
+  word readTwoBytesTogether(int addr_in);
   void writeOneByte(int adr_in, int dat_in);
+
 };
 #endif


### PR DESCRIPTION
Made the following changes:

- Cleaned register addresses, made it match name on datasheet.
   Converted to constants since it's all private anyway.

- Class variable that are private moved to where they were used.
   No point since user cannot access.
   No method uses them for previous data / sharing.

- CRITICAL: Reverted some previously accepted 

   (1) Raw Angle, Angle, Magnitude
        as per datasheet, read 2 bytes on the same address only applies to these
        presumably those that can dynamically change while in operation

        same as my accepted pull request
        read 2 bytes from the same address

   (2) zpos, mpos, mang, conf

         reverted to before my accepted pull request
         I'm undoing what you accepted for these 4,
         read each byte independently then assemble

- Tested working on ESP32 and Arduino
