### PR TITLE
Remove _maxAngle on line 322

### DIFF
--- a/src/AS5600.cpp
+++ b/src/AS5600.cpp
@@ -319,7 +319,6 @@ int AMS_5600::burnAngle()
 {
   word _zPosition = getStartPosition();
   word _mPosition = getEndPosition();
-  word _maxAngle = getMaxAngle();
 
   int retVal = 1;
   if (detectMagnet() == 1) {


### PR DESCRIPTION
I just removed one line that declared a variable but didn't use it. Seeing the warning for it on compilation has been driving me crazy, so hopefully there won't be any warnings from the library anymore.